### PR TITLE
Fix Integrate tab SVG arrows

### DIFF
--- a/AzureFunctions.Client/templates/function-integrate-v2.component.html
+++ b/AzureFunctions.Client/templates/function-integrate-v2.component.html
@@ -8,9 +8,9 @@
         </div>
     </div>
     <div class="col-md-3">
-        <svg width="100%" viewBox="0 0 250 50" height="40px">
-            <polygon fill=black stroke-width=0
-                     points="0,23 200,23 200,20 250,25 200,30 200,27 0,27" />
+        <!-- SVG right arrow -->
+        <svg height="40px" viewBox="0 0 42 16" width="100%">
+            <path fill="#ccc" d="M1 9v-2h40v-2l3 3-3 3v-2z"></path>
         </svg>
     </div>
     <div class="col-md-1">
@@ -20,9 +20,9 @@
         </div>
     </div>
     <div class="col-md-3">
-        <svg width="100%" viewBox="0 0 250 50" height="40px">
-            <polygon fill=black stroke-width=0
-                     points="0,23 200,23 200,20 250,25 200,30 200,27 0,27" />
+        <!-- SVG right arrow -->
+        <svg height="40px" viewBox="0 0 42 16" width="100%">
+            <path fill="#ccc" d="M1 9v-2h40v-2l3 3-3 3v-2z"></path>
         </svg>
     </div>
     <div class="col-md-1">


### PR DESCRIPTION
In __Integrate__ tab (Trigger --> Input --> Output), replaced decent-but-overstretched-arrows with better looking arrows:

__BEFORE__
![badarrows](https://cloud.githubusercontent.com/assets/6472374/14228862/c7db6c20-f92b-11e5-889c-a93750e2e534.PNG)


__AFTER__
![goodarrows](https://cloud.githubusercontent.com/assets/6472374/14228864/c9387108-f92b-11e5-8901-675204d62e12.PNG)

Tested in Edge (25.10586) and Chrome (49.0.something).