### PR TITLE
DCR: Hiding the Monitoring tab for App level

### DIFF
--- a/AzureFunctions.Client/templates/top-bar.component.html
+++ b/AzureFunctions.Client/templates/top-bar.component.html
@@ -26,13 +26,13 @@
             <i class="fa fa-wrench"></i> Function app settings
         </span>
 
-        <span *ngIf="!gettingStarted"
+        <!--<span *ngIf="!gettingStarted"
               class="top-bar-tool clickable"
               (click)="onAppMonitoringClicked()"
               [class.top-bar-settings-selected]="ActiveButton.toString() === 'AppMonitoring'">
 
             <i class="fa fa-clock-o"></i> Monitoring
-        </span>
+        </span>-->
 
         <span *ngIf="!gettingStarted"
               class="top-bar-tool clickable"


### PR DESCRIPTION
Hiding the Monitoring tab on the Function App - temporarily (mostly for GA as well) until the APIs are updated.