### PR TITLE
Removing whitespace in develop tab

### DIFF
--- a/AzureFunctions.Client/templates/function-dev.component.html
+++ b/AzureFunctions.Client/templates/function-dev.component.html
@@ -1,4 +1,4 @@
-﻿<div style="width: 90%" *ngIf="scriptFile">
+﻿<div *ngIf="scriptFile">
     <div class="gutter-container">
         <div *ngIf="showFunctionInvokeUrl"><label>{{ 'functionDev_functionUrl' | translate }}</label></div>
         <div *ngIf="showFunctionInvokeUrl"><copy-pre [content]="functionInvokeUrl"></copy-pre></div>


### PR DESCRIPTION
Addressing a pet peeve of mine. Just getting rid of a width=90% inline style so that the editor, logs, and run now take up more of the viewport instead of leaving dead space.