### PR TITLE
Fix capitalization of GitHub in translations

### DIFF
--- a/AzureFunctions/ResourcesPortal/Resources.Designer.cs
+++ b/AzureFunctions/ResourcesPortal/Resources.Designer.cs
@@ -781,7 +781,7 @@ namespace AzureFunctions.ResourcesPortal {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Github Secret:.
+        ///   Looks up a localized string similar to GitHub Secret:.
         /// </summary>
         internal static string functionDev_githubSelect {
             get {

--- a/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>Function Url:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github Secret:</value>
+    <value>GitHub Secret:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Hide files</value>

--- a/AzureFunctions/ResourcesPortal/ja-JP/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ja-JP/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>関数の URL:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github シークレット:</value>
+    <value>GitHub シークレット:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>ファイルを非表示にする</value>

--- a/AzureFunctions/ResourcesPortal/ko-KR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ko-KR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>함수 URL:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github 암호:</value>
+    <value>GitHub 암호:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>파일 숨기기</value>

--- a/AzureFunctions/ResourcesPortal/nl-NL/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/nl-NL/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>Functie-URL:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github-geheim:</value>
+    <value>GitHub-geheim:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Bestanden verbergen</value>

--- a/AzureFunctions/ResourcesPortal/pl-PL/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/pl-PL/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>Adres URL funkcji:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Klucz tajny usługi Github:</value>
+    <value>Klucz tajny usługi GitHub:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Ukryj pliki</value>

--- a/AzureFunctions/ResourcesPortal/qps-ploc/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/qps-ploc/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>[z2m32][ëìFunction Url: !!! !!]</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>[G33l1][©üGithub Secret: !!! !!]</value>
+    <value>[G33l1][©üGitHub Secret: !!! !!]</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>[hZWeI][ýÏHide files !!! !]</value>

--- a/AzureFunctions/ResourcesPortal/ru-RU/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/ru-RU/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>URL-адрес функции:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Секрет Github:</value>
+    <value>Секрет GitHub:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Скрыть файлы</value>

--- a/AzureFunctions/ResourcesPortal/sv-SE/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/sv-SE/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>Funktionswebbadress:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github-hemlighet:</value>
+    <value>GitHub-hemlighet:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Dölj filer</value>

--- a/AzureFunctions/ResourcesPortal/tr-TR/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/tr-TR/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>İşlev Url'si:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github Gizli Anahtarı:</value>
+    <value>GitHub Gizli Anahtarı:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>Dosyaları gizle</value>

--- a/AzureFunctions/ResourcesPortal/zh-CN/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/zh-CN/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>函数 URL:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github 机密:</value>
+    <value>GitHub 机密:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>隐藏文件</value>

--- a/AzureFunctions/ResourcesPortal/zh-TW/AzureFunctions/ResourcesPortal/Resources.resx
+++ b/AzureFunctions/ResourcesPortal/zh-TW/AzureFunctions/ResourcesPortal/Resources.resx
@@ -142,7 +142,7 @@
     <value>函式 URL:</value>
   </data>
   <data name="functionDev_githubSelect" xml:space="preserve">
-    <value>Github 密碼:</value>
+    <value>GitHub 密碼:</value>
   </data>
   <data name="functionDev_hideFiles" xml:space="preserve">
     <value>隱藏檔案</value>


### PR DESCRIPTION
Spotted this while trying out the GitHub excellent web hook templates in the portal.

<img alt="Image showing wrong capitalization in the Azure functions portal" src="https://cloud.githubusercontent.com/assets/634063/18343443/b5b5b32a-75b3-11e6-9b62-7df92f192624.png" width="489" />

:heart: