### PR TITLE
check for host secrets to be null to avoid race condition between getting the secrets and trying to display them

### DIFF
--- a/AzureFunctions.Client/app/components/function-dev.component.ts
+++ b/AzureFunctions.Client/app/components/function-dev.component.ts
@@ -211,7 +211,7 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
             code = '';
         } else if (this.isHttpFunction && this.secrets && this.secrets.key) {
             code = `?code=${this.secrets.key}`;
-        } else if (this.isHttpFunction && this._functionsService && this._functionsService.HostSecrets.functionKey) {
+        } else if (this.isHttpFunction && this._functionsService.HostSecrets && this._functionsService.HostSecrets.functionKey) {
             code = `?code=${this._functionsService.HostSecrets.functionKey}`;
         }
         return this._functionsService.getFunctionInvokeUrl(this.functionInfo) + code;

--- a/AzureFunctions.Client/app/components/function-dev.component.ts
+++ b/AzureFunctions.Client/app/components/function-dev.component.ts
@@ -207,11 +207,11 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
     //TODO: change to field;
     get functionInvokeUrl(): string {
         var code = '';
-        if (this.webHookType === 'github' || this.authLevel === 'anonymous' || this._functionsService.HostSecrets === undefined) {
+        if (this.webHookType === 'github' || this.authLevel === 'anonymous') {
             code = '';
         } else if (this.isHttpFunction && this.secrets && this.secrets.key) {
             code = `?code=${this.secrets.key}`;
-        } else if (this.isHttpFunction && this._functionsService.HostSecrets.functionKey) {
+        } else if (this.isHttpFunction && this._functionsService && this._functionsService.HostSecrets.functionKey) {
             code = `?code=${this._functionsService.HostSecrets.functionKey}`;
         }
         return this._functionsService.getFunctionInvokeUrl(this.functionInfo) + code;

--- a/AzureFunctions.Client/app/components/function-dev.component.ts
+++ b/AzureFunctions.Client/app/components/function-dev.component.ts
@@ -207,7 +207,7 @@ export class FunctionDevComponent implements OnChanges, OnDestroy {
     //TODO: change to field;
     get functionInvokeUrl(): string {
         var code = '';
-        if (this.webHookType === 'github' || this.authLevel === 'anonymous') {
+        if (this.webHookType === 'github' || this.authLevel === 'anonymous' || this._functionsService.HostSecrets === undefined) {
             code = '';
         } else if (this.isHttpFunction && this.secrets && this.secrets.key) {
             code = `?code=${this.secrets.key}`;


### PR DESCRIPTION
Fixes this stack
`
"TypeError: Cannot read property 'functionKey' of undefined
    at FunctionDevComponent.get [as functionInvokeUrl] (https://functions-next.azure.com/sfx/app.js?v=fe2781ed:22469:81)
    at DebugAppView._View_FunctionDevComponent3.detectChangesInternal (FunctionDevComponent.template.js:659:45)

`