### PR TITLE
Bug:#696-Monitoring Tab: Invocation Details disappear on clicking ref…

### DIFF
--- a/AzureFunctions.Client/app/components/function-monitor.component.ts
+++ b/AzureFunctions.Client/app/components/function-monitor.component.ts
@@ -27,10 +27,10 @@ export class FunctionMonitorComponent implements OnChanges {
     public errorsAggregateHeading: string;
     public successAggregate: string;
     public errorsAggregate: string;
-    public funcName: string;
     public columns: any[];
+    public functionId: string;
 
-    private _functionId: string;
+    public _funcName: string;
 
     constructor(
         private _functionsService: FunctionsService,
@@ -68,21 +68,21 @@ export class FunctionMonitorComponent implements OnChanges {
         let site = this._functionsService.getSiteName();
         this.successAggregateHeading = this._translateService.instant(PortalResources.functionMonitor_successAggregate);
         this.errorsAggregateHeading = this._translateService.instant(PortalResources.functionMonitor_errorsAggregate);
-        this.funcName = this.selectedFunction.name;
+        this._funcName = this.selectedFunction.name;
         this._functionsService.getFunctionAppId().subscribe(host => {
             var hostId = !!host ? host : "";
-            this._functionMonitorService.getDataForSelectedFunction(this.funcName, hostId).subscribe(data => {
-                this._functionId = !!data ? data.functionId : this.funcName;
+            this._functionMonitorService.getDataForSelectedFunction(this._funcName, hostId).subscribe(data => {
+                this.functionId = !!data ? data.functionId : this._funcName;
                 this.successAggregate = !!data ? data.successCount.toString() : this._translateService.instant(PortalResources.appMonitoring_noData);
                 this.errorsAggregate = !!data ? data.failedCount.toString() : this._translateService.instant(PortalResources.appMonitoring_noData);
 
-                this._functionMonitorService.getInvocationsDataForSelctedFunction(this._functionId).subscribe(result => {
+                this._functionMonitorService.getInvocationsDataForSelctedFunction(this.functionId).subscribe(result => {
                     this.rows = result;
                     this._globalStateService.clearBusyState();
                 });
             });
         });
 
-        this.pulseUrl = `https://support-bay.scm.azurewebsites.net/Support.functionsmetrics/#/${site}/${this.funcName}`;
+        this.pulseUrl = `https://support-bay.scm.azurewebsites.net/Support.functionsmetrics/#/${site}/${this._funcName}`;
     }
 }

--- a/AzureFunctions.Client/app/components/table-function-monitor.component.ts
+++ b/AzureFunctions.Client/app/components/table-function-monitor.component.ts
@@ -24,7 +24,7 @@ export class TableFunctionMonitor implements OnChanges {
     @Input() data: any[];
     @Input() details: any;
     @Input() pulseUrl: string;
-    @Input() selectedFuncName: string;
+    @Input() selectedFuncId: string;
 
     public outputLog: string;
     public selectedRowId: string;
@@ -57,7 +57,7 @@ export class TableFunctionMonitor implements OnChanges {
 
     refreshFuncMonitorGridData() {
         this.setBusyState();
-        this._functionMonitorService.getInvocationsDataForSelctedFunction(this.selectedFuncName).subscribe(result => {
+        this._functionMonitorService.getInvocationsDataForSelctedFunction(this.selectedFuncId).subscribe(result => {
             this.data = result;
             this.clearBusyState();
         });

--- a/AzureFunctions.Client/templates/function-monitoring.component.html
+++ b/AzureFunctions.Client/templates/function-monitoring.component.html
@@ -4,5 +4,5 @@
         <aggregate-block [title]="errorsAggregateHeading" [value]="errorsAggregate" style="float:right; width: 45%">Loading...</aggregate-block>
         <div style="clear: both"></div>
     </div>
-    <table-function-monitor [columns]="columns" [data]="rows" [pulseUrl]="pulseUrl" [selectedFuncName]="funcName"></table-function-monitor>
+    <table-function-monitor [columns]="columns" [data]="rows" [pulseUrl]="pulseUrl" [selectedFuncId]="functionId"></table-function-monitor>
 </div>


### PR DESCRIPTION
This is a regression from the latet updates to monitoring tab - where we need to use funtionId instead of functionName to  GET monitoting data