### PR TITLE
Monitoring GA fixes

### DIFF
--- a/AzureFunctions.Client/app/components/function-monitor.component.ts
+++ b/AzureFunctions.Client/app/components/function-monitor.component.ts
@@ -72,14 +72,19 @@ export class FunctionMonitorComponent implements OnChanges {
         this._functionsService.getFunctionAppId().subscribe(host => {
             var hostId = !!host ? host : "";
             this._functionMonitorService.getDataForSelectedFunction(this._funcName, hostId).subscribe(data => {
-                this.functionId = !!data ? data.functionId : this._funcName;
-                this.successAggregate = !!data ? data.successCount.toString() : this._translateService.instant(PortalResources.appMonitoring_noData);
-                this.errorsAggregate = !!data ? data.failedCount.toString() : this._translateService.instant(PortalResources.appMonitoring_noData);
+                this.functionId = !!data ? data.functionId : "";
+                this.successAggregate = !!data ? data.successCount.toString() : 
+                    this._translateService.instant(PortalResources.appMonitoring_noData);
+                this.errorsAggregate = !!data ? data.failedCount.toString() : 
+                    this._translateService.instant(PortalResources.appMonitoring_noData);
 
-                this._functionMonitorService.getInvocationsDataForSelctedFunction(this.functionId).subscribe(result => {
-                    this.rows = result;
-                    this._globalStateService.clearBusyState();
-                });
+                // if no data from function monitoring we don't call the Invocations API since this will return 404
+                if (!!data) {
+                    this._functionMonitorService.getInvocationsDataForSelctedFunction(this.functionId).subscribe(result => {
+                        this.rows = result;
+                        this._globalStateService.clearBusyState();
+                    });
+                }
             });
         });
 

--- a/AzureFunctions.Client/app/components/table-function-monitor.component.ts
+++ b/AzureFunctions.Client/app/components/table-function-monitor.component.ts
@@ -23,6 +23,7 @@ export class TableFunctionMonitor implements OnChanges {
     @Input() columns: any[];
     @Input() data: any[];
     @Input() details: any;
+    @Input() invocation: any;
     @Input() pulseUrl: string;
     @Input() selectedFuncId: string;
 
@@ -32,13 +33,16 @@ export class TableFunctionMonitor implements OnChanges {
     constructor(
         private _functionMonitorService: FunctionMonitorService,
         private _translateService: TranslateService,
-        private _globalStateService: GlobalStateService ) { }
+        private _globalStateService: GlobalStateService) { }
 
     showDetails(rowData: FunctionInvocations) {
         this._functionMonitorService.getInvocationDetailsForSelectedInvocation(rowData.id).subscribe(results => {
-            this.details = results;
-            this.selectedRowId = rowData.id;
-            this.setOutputLogInfo(this.selectedRowId);
+            if (!!results) {
+                this.invocation = results.invocation;
+                this.details = results.parameters;
+                this.selectedRowId = rowData.id;
+                this.setOutputLogInfo(this.selectedRowId);
+            }
         });
         return this.details;
     }

--- a/AzureFunctions.Client/app/pipes/table-function-monitor.pipe.ts
+++ b/AzureFunctions.Client/app/pipes/table-function-monitor.pipe.ts
@@ -29,7 +29,7 @@ export class Format implements PipeTransform {
             case 'number':
                 parsedFloat = !isNaN(parseFloat(input)) ? parseFloat(input) : 0;
                 format = pipeArgs.length > 1 ? pipeArgs[1] : null;
-                return "(" + this.decimalPipe.transform(Math.round(parsedFloat), format) + " ms running time)";
+                return "(" + this.decimalPipe.transform(Math.round(parsedFloat), format) + " ms)";
             case 'datetime':
                 return moment.utc(input).from(moment.utc()); // converts the datetime to a diff from current datetime
             default:

--- a/AzureFunctions.Client/app/services/function-monitor.service.ts
+++ b/AzureFunctions.Client/app/services/function-monitor.service.ts
@@ -60,8 +60,8 @@ export class FunctionMonitorService {
         return this._http.get(url, {
             headers: this.getHeadersForScmSite(this._globalStateService.ScmCreds)
         })
-            .map<FunctionInvocationDetails[]>(r => r.json().parameters)
-            .catch(e => Observable.of([]));
+            .map<any>(r => r.json())
+            .catch(e => Observable.of(null));
     }
 
     getOutputDetailsForSelectedInvocation(invocationId: string) {

--- a/AzureFunctions.Client/templates/table-function-monitor.html
+++ b/AzureFunctions.Client/templates/table-function-monitor.html
@@ -36,13 +36,18 @@
         <table id="function-monitor-Invocation-details">
             <thead>
                 <tr>
-                    <th>{{'functionMonitorInvocationTable_paramColumn' | translate}}</th>
+                    <th>{{'functionMonitorInvocationTable_paramColumn' | translate}}
+                    </th>
                 </tr>
             </thead>
             <tbody>
                 <tr *ngFor="let item of details">
                     <td>{{item?.name}}</td>
                     <td>{{item?.argInvokeString}}</td>
+                </tr>
+                <tr>
+                    <td>{{invocation?.exceptionType}}</td>
+                    <td>{{invocation?.exceptionMessage}} </td>
                 </tr>
             </tbody>
         </table>


### PR DESCRIPTION
Has fixes for the following
If a function has not run before, we don't know the functionId for it.  #731 
Functions portal: Display error messages  #622 
Monitor tab: remove 'running time' text  #678 