### PR TITLE
Moving busy state for swagger so that you can still navigate between between tabs while it loads

### DIFF
--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.html
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.html
@@ -1,7 +1,9 @@
+<!-- TODO: Should probably come up with a better way to control styling for the container -->
 <div class="container"
     [class.try-functions-busy]="name === 'try-functions'"
     [class.global]="isGlobal"
     [class.busy-dashboard]="name === 'dashboard'"
+    [class.busy-site-tabs]="name === 'site-tabs'"
     *ngIf="busy">
 
     <div class="fxs-progress" *ngIf="name !== 'try-functions'">

--- a/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.scss
+++ b/AzureFunctions.AngularClient/src/app/busy-state/busy-state.component.scss
@@ -23,6 +23,11 @@
   margin-left: $sidenav-width;
 }
 
+.busy-site-tabs{
+  width: calc(100% - #{$sidenav-width});  
+  height: calc(100% - #{$top-bar-height} - 1px);
+}
+
 @-webkit-keyframes fxs-progress-animatedEllipses {
   0% {
     opacity: 1;

--- a/AzureFunctions.AngularClient/src/app/tabs/tabs.component.html
+++ b/AzureFunctions.AngularClient/src/app/tabs/tabs.component.html
@@ -13,6 +13,7 @@
       </li>
     </ul>
     <div class="tab-content">
+        <busy-state name="site-tabs"></busy-state>
         <ng-content></ng-content>
     </div>
 </nav>

--- a/AzureFunctions.AngularClient/src/app/tabs/tabs.component.ts
+++ b/AzureFunctions.AngularClient/src/app/tabs/tabs.component.ts
@@ -1,5 +1,6 @@
+import { BusyStateComponent } from './../busy-state/busy-state.component';
 import { AiService } from './../shared/services/ai.service';
-import { Component, ContentChildren, QueryList, AfterContentInit, Output, EventEmitter } from '@angular/core';
+import { Component, ContentChildren, QueryList, AfterContentInit, Output, EventEmitter, ViewChild } from '@angular/core';
 import { TabComponent } from '../tab/tab.component';
 import { PortalService } from '../shared/services/portal.service';
 
@@ -10,6 +11,7 @@ import { PortalService } from '../shared/services/portal.service';
 })
 export class TabsComponent implements AfterContentInit {
 
+    @ViewChild(BusyStateComponent) busyState : BusyStateComponent;
     @ContentChildren(TabComponent) tabs: QueryList<TabComponent>;
     @Output() tabSelected = new EventEmitter<TabComponent>();
     @Output() tabClosed = new EventEmitter<TabComponent>();


### PR DESCRIPTION
If the site is taking a while to load, the API definition tab will lock the tabs navigation because the busy state will cover it all up.  So I'm moving the busy state under the tabs component.  I'll move the other tabs to use this later as well.