### PR TITLE
fix localise method in function-app.ts

### DIFF
--- a/AzureFunctions.AngularClient/src/app/shared/function-app.ts
+++ b/AzureFunctions.AngularClient/src/app/shared/function-app.ts
@@ -1440,28 +1440,19 @@ export class FunctionApp {
 
     private localize(objectToLocalize: any): any {
         if ((typeof objectToLocalize === 'string') && (objectToLocalize.startsWith('$'))) {
-            return this._translateService.instant(objectToLocalize.substring(1, objectToLocalize.length));
-        }
-
-        for (const property in objectToLocalize) {
-            if (property === 'files' || property === 'defaultValue') {
-                continue;
+            const key = objectToLocalize.substring(1, objectToLocalize.length);
+            objectToLocalize = this._translateService.instant(key);
+        } else if (Array.isArray(objectToLocalize)) {
+            for (let i = 0; i < objectToLocalize.length; i++) {
+                objectToLocalize[i] =  this.localize(objectToLocalize[i]);
             }
-
-            if (objectToLocalize.hasOwnProperty(property)) {
-                const value = objectToLocalize[property];
-                if ((typeof value === 'string') && (value.startsWith('$'))) {
-                    const key = value.substring(1, value.length);
-                    const locString = this._translateService.instant(key);
-                    if (locString !== key) {
-                        objectToLocalize[property] = locString;
-                    }
-                } else if (Array.isArray(value)) {
-                    for (let i = 0; i < value.length; i++) {
-                        value[i] =  this.localize(value[i]);
-                    }
-                } else if (typeof value === 'object') {
-                    objectToLocalize[property] = this.localize(value);
+        } else if (typeof objectToLocalize === 'object') {
+            for (const property in objectToLocalize) {
+                if (property === 'files' || property === 'defaultValue') {
+                    continue;
+                }
+                if (objectToLocalize.hasOwnProperty(property)) {
+                    objectToLocalize[property] = this.localize(objectToLocalize[property]);
                 }
             }
         }


### PR DESCRIPTION
there are 3 changes here:
* `function-integrate-v2.component.ts` changes are to fix a bug when running locally or without --prod in general. The issue is that a value changes too quickly and you get an error from angular saying that a value changed after it was checked.  This happen if you have an unsupported `function.json` file, say if you have an unknown type for a binding in there.
* `monaco-editor.directive.ts` are needed due to the upgrade of angular cli. it writes the output into a folder called `ng` not `ng2app`.
* `function-app.ts` this change is to fix localize method there to properly localize objects.