### PR TITLE
enabled ie11 polyfills

### DIFF
--- a/AzureFunctions.AngularClient/src/polyfills.ts
+++ b/AzureFunctions.AngularClient/src/polyfills.ts
@@ -19,19 +19,19 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-// import 'core-js/es6/symbol';
-// import 'core-js/es6/object';
-// import 'core-js/es6/function';
-// import 'core-js/es6/parse-int';
-// import 'core-js/es6/parse-float';
-// import 'core-js/es6/number';
-// import 'core-js/es6/math';
-// import 'core-js/es6/string';
-// import 'core-js/es6/date';
-// import 'core-js/es6/array';
-// import 'core-js/es6/regexp';
-// import 'core-js/es6/map';
-// import 'core-js/es6/set';
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.


### PR DESCRIPTION
Should fix the bug where it won't run in IE11. We enabled the IE11 polyfills in `polyfills.ts`

Please test this in IE11

Technically, the error before was in `object.assign.apply`. So we may only need `import 'core-js/es6/object';`. Let's first test it with all of these enabled. Then, if that works, then we can try just this one file .... which is better so we bundle less. It's not a huge amount though .... so I recommend just enabling all of these polyfills for now.