### PR TITLE
#1327: Hide restart command for Function App & slots

### DIFF
--- a/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
+++ b/AzureFunctions.AngularClient/src/app/site/site-summary/site-summary.component.html
@@ -10,14 +10,10 @@
     <span class="clickable" [class.disabled-action]="!hasWriteAccess || !hasSwapAccess || site?.properties.targetSwapSlot !== null" (click) = "openSwapBlade()">
             <img src="images/swap.svg" />{{ 'swap' | translate }}
     </span>
-    <!-- Disable restart command for Function App & slots  #1327 -->
+    <!-- Hide restart command for Function App & slots  #1327 -->
     <!--<span class="clickable" [class.disabled-action]="!hasWriteAccess || site?.properties.state !== 'Running'" (click)="restart()">
         <img src="images/restart.svg" />{{ 'restart' | translate }}
-    </span>-->    
-    <!-- Remove this when the bug blocking restart is fixed -->
-    <span class="clickable disabled-action">
-        <img src="images/restart.svg" />{{ 'restart' | translate }}
-    </span>
+    </span>-->
 
     <span class="clickable" [class.disabled-action]="!hasWriteAccess" (click)="downloadPublishProfile($event)">
         <img src="images/download.svg" />{{ 'downloadProfile' | translate}}


### PR DESCRIPTION
Hiding the restart button completely instead of disabling it in order to reduce the confusion